### PR TITLE
Disable spell checking for code regions.

### DIFF
--- a/syntax/slack.vim
+++ b/syntax/slack.vim
@@ -19,10 +19,10 @@ syn region slackFormatItalic start="\%(^\|\s\)\@<=_\S\@=" end="\S\@<=_\%($\|\s\|
 syn region slackFormatStrike start="\%(^\|\s\)\@<=\~\S\@=" end="\S\@<=\~\%($\|\s\|[[:punct:]]\)\@<=" keepend
 
 "   inline code block `inline code`
-syn region slackFormatInlineCode start="\%(^\|\s\)\`\S\@=" end="\S\@<=\`\%($\|\s\|[[:punct:]]\)\@<=" keepend
+syn region slackFormatInlineCode start="\%(^\|\s\)\`\S\@=" end="\S\@<=\`\%($\|\s\|[[:punct:]]\)\@<=" keepend contains=@NoSpell
 
 "   block of preformated fixed with code ```code and stuff``` 
-syn region slackFormatCodeBlock start="^\s*```" end="\s*```$" keepend fold
+syn region slackFormatCodeBlock start="^\s*```" end="\s*```$" keepend fold contains=@NoSpell
 
 "   > to block quote one paragraph
 "   >>> to block quote multiple paragraphs


### PR DESCRIPTION
Hi, thanks again for this syntax file. I'm not using it throughout the day, but often when I'm composing a larger message I like to hit Vim and when I do this syntax comes in super handy.

One minor gripe I currently have is that if I paste a code block I get a load of spelling issues highlighted. This pull request disables spell checking for code regions.